### PR TITLE
Update project order by user activity

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -13,4 +13,6 @@ class Entry < ActiveRecord::Base
 
   belongs_to :user, touch: true
   belongs_to :project, touch: true
+
+
 end

--- a/app/models/hour.rb
+++ b/app/models/hour.rb
@@ -34,6 +34,7 @@ class Hour < Entry
   }
 
   before_save :set_tags_from_description
+  after_create :update_activity_user
 
   def tag_list
     tags.map(&:name).join(", ")
@@ -53,5 +54,9 @@ class Hour < Entry
         tag.save!
       end
     end
+  end
+
+  def update_activity_user
+    self.project.update_user_activity
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,6 +30,7 @@ class Project < ActiveRecord::Base
   belongs_to :client, touch: true
 
   scope :by_last_updated, -> { order("projects.updated_at DESC") }
+  scope :by_user_activity, -> { order("projects.user_activity DESC") }
   scope :by_name, -> { order("lower(name)") }
 
   scope :are_archived, -> { where(archived: true) }
@@ -48,6 +49,11 @@ class Project < ActiveRecord::Base
 
   def budget_status
     budget - hours.sum(:value) if budget
+  end
+
+  def update_user_activity
+    self.user_activity = DateTime.now
+    self.save
   end
 
   private

--- a/app/views/application/_hours_entry_form.html.haml
+++ b/app/views/application/_hours_entry_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for @hours_entry do |f|
   = f.error_notification
-  = f.association :project, required: true, collection: Project.unarchived.by_name, label: false, placeholder: t("entries.index.project")
+  = f.association :project, required: true, collection: Project.unarchived.by_user_activity, label: false, placeholder: t("entries.index.project")
   = f.association :category, required: true, collection: Category.by_name, label: false, placeholder: t("entries.index.category")
   = f.input :value, required: true, label: false, placeholder: t("entries.index.hours")
   = f.input :date, required: true, as: :string, input_html: { value: (@hours_entry.date || DateTime.current).strftime("%d/%m/%Y"), class: "datepicker"}, label: false

--- a/db/migrate/20150921111033_add_last_user_activity_to_projects.rb
+++ b/db/migrate/20150921111033_add_last_user_activity_to_projects.rb
@@ -1,0 +1,6 @@
+class AddLastUserActivityToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :user_activity, :date, :default => DateTime.now
+    add_index :projects, :user_activity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150224115957) do
+ActiveRecord::Schema.define(version: 20150921111033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,20 +113,22 @@ ActiveRecord::Schema.define(version: 20150224115957) do
   add_index "mileages", ["user_id"], name: "index_mileages_on_user_id", using: :btree
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name",        default: "",    null: false
+    t.string   "name",          default: "",           null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug"
     t.integer  "budget"
-    t.boolean  "billable",    default: false
+    t.boolean  "billable",      default: false
     t.integer  "client_id"
-    t.boolean  "archived",    default: false, null: false
+    t.boolean  "archived",      default: false,        null: false
     t.text     "description"
+    t.date     "user_activity", default: '2015-09-21'
   end
 
   add_index "projects", ["archived"], name: "index_projects_on_archived", using: :btree
   add_index "projects", ["billable"], name: "index_projects_on_billable", using: :btree
   add_index "projects", ["slug"], name: "index_projects_on_slug", using: :btree
+  add_index "projects", ["user_activity"], name: "index_projects_on_user_activity", using: :btree
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -71,6 +71,24 @@ describe Project do
     end
   end
 
+  describe "#by_user_activity" do
+    it "orders the projects by user activity" do
+      project = create(:project)
+      create(:project)
+      project.update_user_activity
+
+      expect(Project.by_user_activity.first).to eq(project)
+    end
+
+    it "Update activity project after new entry" do
+      project = create(:project)
+      create(:project)
+      create(:hour,:project_id => project.id)
+
+      expect(Project.by_user_activity.first).to eq(project)
+    end
+  end
+
   describe "#by_name" do
     it "orders by name case insensitive" do
       create(:project, name: "B")


### PR DESCRIPTION
Update projects order by user activity. Add new field to Project model: user_activity (date). This field will be updated with each event that can consider an project update into the project philosophy, example, new hours entry. 